### PR TITLE
style: Apply formatting changes to match accepted PEPs

### DIFF
--- a/pep-NNN.rst
+++ b/pep-NNN.rst
@@ -74,18 +74,18 @@ Specification
 [Describe the syntax and semantics of any new language feature.]
 
 1. When a module (or package) includes a version number, the version SHOULD be
-   available in the __version__ attribute.
+   available in the `__version__` attribute.
 2. For modules which live inside a namespace package, the module SHOULD include
-   the __version__ attribute. The namespace package itself SHOULD NOT include
-   its own __version__ attribute.
-3. The __version__ attribute’s value MUST be a string.  Module version
+   the `__version__` attribute. The namespace package itself SHOULD NOT include
+   its own `__version__` attribute.
+3. The `__version__` attribute’s value MUST be a string.  Module version
    numbers SHOULD conform to the normalized version format specified in PEP 440.
 4. Module version numbers MAY contain version control system supplied information or
    other semantically different version numbers (e.g. underlying library
    version number) consistent with PEP 440.
-5. The __version__ attribute SHOULD be consistent with the importlib.metadata
+5. The `__version__` attribute SHOULD be consistent with the `importlib.metadata`
    information.
-6. Packages MAY dynamically compute the __version__ string at runtime.
+6. Packages MAY dynamically compute the `__version__` string at runtime.
 
 
 Backwards Compatibility
@@ -124,10 +124,10 @@ Rejected Ideas
 [Why certain ideas that were brought while discussing this PEP were not
 ultimately pursued.]
 
-**relying solely on importlib**
+**relying solely on `importlib`**
 
 As discussed above there are many cases where the metadata may not exist and
-importlib is solving a different problem.  Additionally accessing an attribute
+`importlib` is solving a different problem.  Additionally accessing an attribute
 is a very simple ergonomic API to access the version of a module currently in
 your namespace.
 
@@ -136,7 +136,7 @@ Open Issues
 
 [Any points that are still being decided/discussed.]
 
-Deferring any discussion of if modules should automatically fallback to importlib
+Deferring any discussion of if modules should automatically fallback to `importlib`
 when the user access `__version__` and it is not otherwise defined.
 
 None

--- a/pep-NNN.rst
+++ b/pep-NNN.rst
@@ -60,7 +60,7 @@ Rationale
 
 We chose the name `__version__` for the attribute because there is a long
 standing convention of using the attribute for this purpose.  There was
-PEP 396 [0] from 2011 which was recently abandoned and is well established
+PEP 396 [1]_ from 2011 which was recently abandoned and is well established
 in the Scientific Python community [maybe get numbers?].  The specification
 in this PEP is a lightly adapted version of the text in PEP 396.
 
@@ -146,7 +146,8 @@ Footnotes
 
 [A collection of footnotes cited in the PEP, and a place to list non-inline hyperlink targets.]
 
-[0] https://peps.python.org/pep-0396/
+.. [1] PEP 396 - Module Version Numbers
+   https://peps.python.org/pep-0396/
 
 Copyright
 =========

--- a/pep-NNN.rst
+++ b/pep-NNN.rst
@@ -30,7 +30,7 @@ Motivation
 
 In many contexts it useful to know the run-time version of an imported module.
 This can be used both for attaching meta-data for provenance or for feature/bug
-gating. While the pypa has made progress on defining and accessing package
+gating. While the PyPA has made progress on defining and accessing package
 versions for distributions and environment solving, run time versions have
 different use cases.
 


### PR DESCRIPTION
@tacaswell This is just minor formatting issues to match the format of things like [PEP 440](https://peps.python.org/pep-0440/).